### PR TITLE
Workflow triggers

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -1,8 +1,6 @@
 name: Publish to Test PyPI
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   test_pypi_release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,10 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - '*.*.*'
+  workflow_dispatch:
+  release:
+    types:
+      - created
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ export OPENAI_API_KEY=<insert your openai key>
 - [ ] Publish the package to PyPI.
 - [ ] Expand test coverage.
 - [ ] Show tests passing & coverage as github badges.
-- [ ] Fix CI/CD -- Address the issue where the pre-release deployment to PyPI fails due to the need for version update.
+- [X] Fix CI/CD -- Address the issue where the pre-release deployment to PyPI fails due to the need for version update.
 - [ ] Add docstrings.
 - [ ] Generate docs (from docstrings).
 

--- a/src/openai_decorator/__init__.py
+++ b/src/openai_decorator/__init__.py
@@ -1,0 +1,1 @@
+from .main import openai_func


### PR DESCRIPTION
- The release workflow is now only triggered when a release is created on github
- The pre-release workflow now has to be manually run on github. This is necessary as the pre-release requires a version bump.